### PR TITLE
add sticky header for sync tasks table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Add sticky header in the sync tasks table for long tables
+
 ## [v0.5.0] - 2024-05-06
 
 ### Added

--- a/src-tauri/src/integrations/redmine.rs
+++ b/src-tauri/src/integrations/redmine.rs
@@ -185,7 +185,9 @@ impl Redmine {
 
         let unwrapped_response = response.unwrap();
 
-        if unwrapped_response.status() == Status::NOT_FOUND {
+        if unwrapped_response.status() == Status::NOT_FOUND
+            || unwrapped_response.status() == Status::FORBIDDEN
+        {
             return Err(RedmineErrorType::IssueNotFound);
         }
 

--- a/src/components/Sync/Sync.tsx
+++ b/src/components/Sync/Sync.tsx
@@ -46,8 +46,8 @@ const Sync = (props: SyncProps) => {
               No tasks to send. Only finished tasks with an external ID can be.
             </Alert>
           )}
-          <TableContainer>
-            <Table size="small">
+          <TableContainer sx={{ maxHeight: 350 }}>
+            <Table size="small" stickyHeader>
               <TableHead>
                 <TableRow>
                   <TableCell align="left">Description</TableCell>


### PR DESCRIPTION
- **feat: add more control for not found tasks**
- **feat: add sticky header for synctasks table**
- **docs: changelog updated**

Fixes #78
